### PR TITLE
[osflow/.gitignore] update

### DIFF
--- a/osflow/.gitignore
+++ b/osflow/.gitignore
@@ -1,8 +1,10 @@
 *.asc
 *.bit
+*.cf
 *.cfg
 *.dfu
 *.history
 *.json
+*.o
 *.svf
 *-report.txt


### PR DESCRIPTION
This PR updates the `.gitignore` in subdir `osflow`, in order to hide `*.cf` and `*.o` files generated by GHDL's LLVM or GCC backends.