### PR TITLE
[github] add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: gitsubmodule
+  directory: /
+  commit-message:
+    prefix: '[Dependabot]'
+  schedule:
+    interval: weekly
+    time: '04:00'
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This PR adds a dependabot configuration file. Dependabot will create PRs to update the submodules.
I set the interval to weekly updates.