### PR TITLE
[osflow] use workdir 'build' when calling GHDL

### DIFF
--- a/osflow/common.mk
+++ b/osflow/common.mk
@@ -34,6 +34,6 @@ svf: ${IMPL}.svf
 endif
 
 clean:
-	rm -rf *.{${PNR2BIT_EXT},bit,cf,dfu,history,json,o,svf} *-report.txt
+	rm -rf build *.{${PNR2BIT_EXT},bit,cf,dfu,history,json,o,svf} *-report.txt
 
 include boards/$(BOARD).mk

--- a/osflow/synthesis.mk
+++ b/osflow/synthesis.mk
@@ -1,5 +1,6 @@
 ${DEVICE_LIB}-obj08.cf: ${DEVICE_SRC}
-	ghdl -a $(GHDL_FLAGS) --work=${DEVICE_LIB} ${DEVICE_SRC}
+	mkdir -p build
+	ghdl -a $(GHDL_FLAGS) --workdir=build --work=${DEVICE_LIB} ${DEVICE_SRC}
 
 neorv32-obj08.cf: ${DEVICE_LIB}-obj08.cf ${NEORV32_SRC}
 	ghdl -a $(GHDL_FLAGS) --work=neorv32 ${NEORV32_SRC}

--- a/osflow/tools.mk
+++ b/osflow/tools.mk
@@ -1,4 +1,4 @@
-GHDL_FLAGS += --std=08
+GHDL_FLAGS += --std=08 --workdir=build -Pbuild
 GHDL       ?= ghdl
 GHDLSYNTH  ?= ghdl
 YOSYS      ?= yosys


### PR DESCRIPTION
Instead of creating temporary files (`.cf`, `.o`, etc.) in subdir `osflow`, this will use `osflow/build`.