### PR TITLE
[osflow/SPRAM] allow setting of IMEM/DMEM logical size

### DIFF
--- a/osflow/devices/ice40/neorv32_dmem.ice40up_spram.vhd
+++ b/osflow/devices/ice40/neorv32_dmem.ice40up_spram.vhd
@@ -53,7 +53,7 @@ architecture neorv32_dmem_rtl of neorv32_dmem is
 
   -- IO space: module base address --
   constant hi_abb_c : natural := 31; -- high address boundary bit
-  constant lo_abb_c : natural := index_size_f(64*1024); -- low address boundary bit
+  constant lo_abb_c : natural := index_size_f(DMEM_SIZE); -- low address boundary bit
 
   -- local signals --
   signal acc_en : std_ulogic;
@@ -79,7 +79,7 @@ begin
   -- Sanity Checks --------------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
   assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using iCE40up SPRAM-based DMEM." severity note;
-  assert not (DMEM_SIZE > 64*1024) report "NEORV32 PROCESSOR CONFIG ERROR: DMEM has a fixed physical size of 64kB. Logical size must be less or equal." severity error;
+  assert not (DMEM_SIZE /= 64*1024) report "NEORV32 PROCESSOR CONFIG NOTE: DMEM SPRAM has a fixed physical size of 64kB." severity note;
 
 
   -- Access Control -------------------------------------------------------------------------

--- a/osflow/devices/ice40/neorv32_imem.ice40up_spram.vhd
+++ b/osflow/devices/ice40/neorv32_imem.ice40up_spram.vhd
@@ -53,7 +53,7 @@ architecture neorv32_imem_rtl of neorv32_imem is
 
   -- IO space: module base address --
   constant hi_abb_c : natural := 31; -- high address boundary bit
-  constant lo_abb_c : natural := index_size_f(64*1024); -- low address boundary bit
+  constant lo_abb_c : natural := index_size_f(IMEM_SIZE); -- low address boundary bit
 
   -- local signals --
   signal acc_en : std_ulogic;
@@ -80,7 +80,7 @@ begin
   -- -------------------------------------------------------------------------------------------
   assert false report "NEORV32 PROCESSOR CONFIG NOTE: Using iCE40up SPRAM-based IMEM." severity note;
   assert not (IMEM_AS_IROM = true) report "NEORV32 PROCESSOR CONFIG ERROR: ICE40 Ultra Plus SPRAM cannot be initialized by bitstream!" severity failure;
-  assert not (IMEM_SIZE > 64*1024) report "NEORV32 PROCESSOR CONFIG ERROR: IMEM has a fixed physical size of 64kB. Logical size must be less or equal." severity error;
+  assert not (IMEM_SIZE /= 64*1024) report "NEORV32 PROCESSOR CONFIG NOTE: IMEM SPRAM has a fixed physical size of 64kB." severity note;
 
 
   -- Access Control -------------------------------------------------------------------------


### PR DESCRIPTION
The ice40 SPRAM blocks have a fixed **physical** size of 64kB. However, with this PR a smaller **logical** size can be "implemented" using the according IMEM/DMEM size generics.