### PR TITLE
update project for custom DTM with Intel JTAG

### DIFF
--- a/quartus/on-chip-debugger-intel/README.md
+++ b/quartus/on-chip-debugger-intel/README.md
@@ -41,9 +41,9 @@ configuration and entity details.
 ### FPGA Utilization
 
 ```
-Total logic elements                    3,786 / 15,408 ( 25 % )
-Total registers                         1,835 / 17,056 ( 11 % )
-Total LABs                              291 / 963 ( 30 % )
+Total logic elements                    3,791 / 15,408 ( 25 % )
+Total registers                         1,750 / 17,056 ( 11 % )
+Total LABs                              278 / 963 ( 29 % )
 Virtual pins                            0
 I/O pins                                10 / 344 ( 3 % )
 M9Ks                                    30 / 56 ( 54 % )
@@ -56,8 +56,8 @@ CRC blocks                              0 / 1 ( 0 % )
 ASMI blocks                             0 / 1 ( 0 % )
 Oscillator blocks                       0 / 1 ( 0 % )
 Impedance control blocks                0 / 4 ( 0 % )
-Average interconnect usage (total/H/V)  10.2% / 9.9% / 10.6%
-Peak interconnect usage (total/H/V)     36.5% / 36.3% / 36.8%
+Average interconnect usage (total/H/V)  10.0% / 9.4% / 10.7%
+Peak interconnect usage (total/H/V)     39.7% / 37.3% / 43.1%
 ```
 
 

--- a/quartus/on-chip-debugger-intel/neorv32_debug_dtm.intel.vhd
+++ b/quartus/on-chip-debugger-intel/neorv32_debug_dtm.intel.vhd
@@ -2,15 +2,16 @@
 -- # << NEORV32 - RISC-V Debug Transport Module (DTM) >>                                           #
 -- # ********************************************************************************************* #
 -- # Provides an Intel specific JTAG-compatible TAP to access the DMI register interface.          #
+-- # Compatible to the RISC-V debug specification version 1.0.                                     #
 -- # Functionally identical to the default dtm implementation but modified to listen only on USR0  #
 -- # (0x00c) and USR1 (0x00e) ir addresses that are "free to use" in Intel FPGA user designs. This #
--- # expects that the JTAO I/Os are wired to an Intel atom like cycloneive_jtag or similar.        #
+-- # expects that the JTAG I/Os are wired to an Intel atom like cycloneive_jtag or similar.        #
 -- # This principle of operation is based on the excellent blog post of tomverbeure, see:          #
 -- # --> https://tomverbeure.github.io/2021/10/30/Intel-JTAG-Primitive.html.                       #
 -- # ********************************************************************************************* #
 -- # BSD 3-Clause License                                                                          #
 -- #                                                                                               #
--- # Copyright (c) 2023, Stephan Nolting. All rights reserved.                                     #
+-- # Copyright (c) 2023, Stephan Nolting and Niklaus Leuenberger. All rights reserved.             #
 -- #                                                                                               #
 -- # Redistribution and use in source and binary forms, with or without modification, are          #
 -- # permitted provided that the following conditions are met:                                     #
@@ -36,11 +37,17 @@
 -- # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED  #
 -- # OF THE POSSIBILITY OF SUCH DAMAGE.                                                            #
 -- # ********************************************************************************************* #
--- # https://github.com/stnolting/riscv-debug-dtm                              (c) Stephan Nolting #
+-- # Original content by Stephan Nolting.                                                          #
+-- # Modified by Niklaus Leuenberger to support Intel FPGA JTAG atom.                              #
+-- # ********************************************************************************************* #
+-- # The NEORV32 Processor - https://github.com/stnolting/neorv32              (c) Stephan Nolting #
 -- #################################################################################################
 
 library ieee;
 use ieee.std_logic_1164.all;
+
+library neorv32;
+use neorv32.neorv32_package.all;
 
 entity neorv32_debug_dtm is
   generic (
@@ -50,33 +57,34 @@ entity neorv32_debug_dtm is
   );
   port (
     -- global control --
-    clk_i             : in  std_ulogic; -- global clock line
-    rstn_i            : in  std_ulogic; -- global reset line, low-active
+    clk_i       : in  std_ulogic; -- global clock line
+    rstn_i      : in  std_ulogic; -- global reset line, low-active
     -- jtag connection --
-    jtag_trst_i       : in  std_ulogic;
-    jtag_tck_i        : in  std_ulogic;
-    jtag_tdi_i        : in  std_ulogic;
-    jtag_tdo_o        : out std_ulogic;
-    jtag_tms_i        : in  std_ulogic;
+    jtag_trst_i : in  std_ulogic;
+    jtag_tck_i  : in  std_ulogic;
+    jtag_tdi_i  : in  std_ulogic;
+    jtag_tdo_o  : out std_ulogic;
+    jtag_tms_i  : in  std_ulogic;
     -- debug module interface (DMI) --
-    dmi_req_valid_o   : out std_ulogic;
-    dmi_req_ready_i   : in  std_ulogic; -- DMI is allowed to make new requests when set
-    dmi_req_address_o : out std_ulogic_vector(05 downto 0);
-    dmi_req_data_o    : out std_ulogic_vector(31 downto 0);
-    dmi_req_op_o      : out std_ulogic_vector(01 downto 0);
-    dmi_rsp_valid_i   : in  std_ulogic; -- response valid when set
-    dmi_rsp_ready_o   : out std_ulogic; -- ready to receive response
-    dmi_rsp_data_i    : in  std_ulogic_vector(31 downto 0);
-    dmi_rsp_op_i      : in  std_ulogic_vector(01 downto 0)
+    dmi_req_o   : out dmi_req_t; -- request
+    dmi_rsp_i   : in  dmi_rsp_t  -- response
   );
 end neorv32_debug_dtm;
 
 architecture neorv32_debug_dtm_intel_rtl of neorv32_debug_dtm is
 
   -- DMI Configuration (fixed!) --
-  constant dmi_idle_c    : std_ulogic_vector(02 downto 0) := "000"; -- no idle cycles required
-  constant dmi_version_c : std_ulogic_vector(03 downto 0) := "0001"; -- debug spec. version (0.13 & 1.0)
-  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000110"; -- number of DMI address bits (6)
+  constant dmi_idle_c    : std_ulogic_vector(02 downto 0) := "000";    -- no idle cycles required
+  constant dmi_version_c : std_ulogic_vector(03 downto 0) := "0001";   -- debug spec. version (0.13 & 1.0)
+  constant dmi_abits_c   : std_ulogic_vector(05 downto 0) := "000111"; -- number of DMI address bits (7)
+
+  -- TAP data register addresses, adapted for Intel USR0 and USR1 register addresses --
+  -- OpenOCD needs to be informed of these addresses:
+  -- > riscv set_ir dtmcs 0x00c
+  -- > riscv set_ir dmi 0x00e
+  constant addr_idcode_c : std_ulogic_vector(9 downto 0) := "0000000001"; -- identifier (not accessible, only dummy)
+  constant addr_dtmcs_c  : std_ulogic_vector(9 downto 0) := "0000001100"; -- USR0 0x00c
+  constant addr_dmi_c    : std_ulogic_vector(9 downto 0) := "0000001110"; -- USR1 0x00e
 
   -- tap JTAG signal synchronizer --
   type tap_sync_t is record
@@ -94,46 +102,38 @@ architecture neorv32_debug_dtm_intel_rtl of neorv32_debug_dtm is
   end record;
   signal tap_sync : tap_sync_t;
 
-  -- tap controller - fsm --
+  -- tap controller --
   type tap_ctrl_state_t is (LOGIC_RESET, DR_SCAN, DR_CAPTURE, DR_SHIFT, DR_EXIT1, DR_PAUSE, DR_EXIT2, DR_UPDATE,
                                RUN_IDLE, IR_SCAN, IR_CAPTURE, IR_SHIFT, IR_EXIT1, IR_PAUSE, IR_EXIT2, IR_UPDATE);
   signal tap_ctrl_state : tap_ctrl_state_t;
 
-  -- update trigger --
-  type dr_update_trig_t is record
-    valid        : std_ulogic;
-    is_update    : std_ulogic;
-    is_update_ff : std_ulogic;
-  end record;
-  signal dr_update_trig : dr_update_trig_t;
-
-  -- Intel USR0 and USR1 register address --
-  -- OpenOCD needs to be informed of these addresses:
-  -- > riscv set_ir dtmcs 0x00c
-  -- > riscv set_ir dmi 0x00e
-  constant adr_dtmcs_c : std_ulogic_vector(09 downto 0) := "0000001100"; -- USR0 0x00c
-  constant adr_dmi_c : std_ulogic_vector(09 downto 0)   := "0000001110"; -- USR1 0x00e
-
   -- tap registers --
   type tap_reg_t is record
-    -- do not implement idcode and bypass registers, those are handled by the Intel atom
+    -- do not implement bypass register, that is handled by the Intel atom
     ireg             : std_ulogic_vector(09 downto 0); -- size = 10, default on all intel fpgas
+    idcode           : std_ulogic_vector(31 downto 0);
     dtmcs, dtmcs_nxt : std_ulogic_vector(31 downto 0);
-    dmi,   dmi_nxt   : std_ulogic_vector((6+32+2)-1 downto 0); -- 6-bit address + 32-bit data + 2-bit operation
+    dmi,   dmi_nxt   : std_ulogic_vector((7+32+2)-1 downto 0); -- 7-bit address + 32-bit data + 2-bit operation
   end record;
   signal tap_reg : tap_reg_t;
 
-  -- debug module interface --
-  type dmi_ctrl_state_t is (DMI_IDLE, DMI_READ_WAIT, DMI_READ, DMI_READ_BUSY,
-                            DMI_WRITE_WAIT, DMI_WRITE, DMI_WRITE_BUSY);
+  -- update trigger --
+  type dr_trigger_t is record
+    sreg  : std_ulogic_vector(1 downto 0);
+    valid : std_ulogic;
+  end record;
+  signal dr_trigger : dr_trigger_t;
+
+  -- debug module interface controller --
   type dmi_ctrl_t is record
-    state        : dmi_ctrl_state_t;
+    busy         : std_ulogic;
+    op           : std_ulogic_vector(01 downto 0);
     dmihardreset : std_ulogic;
     dmireset     : std_ulogic;
-    rsp          : std_ulogic_vector(01 downto 0); -- sticky response status
+    err          : std_ulogic;
     rdata        : std_ulogic_vector(31 downto 0);
     wdata        : std_ulogic_vector(31 downto 0);
-    addr         : std_ulogic_vector(05 downto 0);
+    addr         : std_ulogic_vector(06 downto 0);
   end record;
   signal dmi_ctrl : dmi_ctrl_t;
 
@@ -203,6 +203,23 @@ begin
     end if;
   end process tap_control;
 
+  -- trigger for UPDATE state --
+  update_trigger: process(rstn_i, clk_i)
+  begin
+    if (rstn_i = '0') then
+      dr_trigger.sreg <= "00";
+    elsif rising_edge(clk_i) then
+      if (tap_ctrl_state = DR_UPDATE) then
+        dr_trigger.sreg(0) <= '1';
+      else
+        dr_trigger.sreg(0) <= '0';
+      end if;
+      dr_trigger.sreg(1) <= dr_trigger.sreg(0);
+    end if;
+  end process update_trigger;
+
+  dr_trigger.valid <= '1' when (dr_trigger.sreg = "01") else '0';
+
 
   -- Tap Register Access --------------------------------------------------------------------
   -- -------------------------------------------------------------------------------------------
@@ -210,13 +227,15 @@ begin
   begin
     if (rstn_i = '0') then
       tap_reg.ireg   <= (others => '0');
+      tap_reg.idcode <= (others => '0');
       tap_reg.dtmcs  <= (others => '0');
       tap_reg.dmi    <= (others => '0');
-      -- jtag_tdo_o     <= '0';
     elsif rising_edge(clk_i) then
 
       -- serial data input: instruction register --
-      if (tap_ctrl_state = IR_SHIFT) then -- access phase
+      if (tap_ctrl_state = LOGIC_RESET) or (tap_ctrl_state = IR_CAPTURE) then -- preload phase
+        tap_reg.ireg <= addr_idcode_c;
+      elsif (tap_ctrl_state = IR_SHIFT) then -- access phase
         if (tap_sync.tck_rising = '1') then -- [JTAG-SYNC] evaluate TDI on rising edge of TCK
           tap_reg.ireg <= tap_sync.tdi & tap_reg.ireg(tap_reg.ireg'left downto 1);
         end if;
@@ -224,18 +243,20 @@ begin
 
       -- serial data input: data register --
       if (tap_ctrl_state = DR_CAPTURE) then -- preload phase
-        if (tap_reg.ireg = adr_dtmcs_c) then -- status register
-          tap_reg.dtmcs <= tap_reg.dtmcs_nxt;
-        elsif (tap_reg.ireg = adr_dmi_c) then -- register interface
-          tap_reg.dmi   <= tap_reg.dmi_nxt;
-        end if;
+        case tap_reg.ireg is
+          when addr_idcode_c => tap_reg.idcode <= IDCODE_VERSION & IDCODE_PARTID & IDCODE_MANID & '1'; -- identifier (LSB has to be set)
+          when addr_dtmcs_c  => tap_reg.dtmcs  <= tap_reg.dtmcs_nxt; -- status register
+          when addr_dmi_c    => tap_reg.dmi    <= tap_reg.dmi_nxt; -- register interface
+          when others        => null;
+        end case;
       elsif (tap_ctrl_state = DR_SHIFT) then -- access phase
         if (tap_sync.tck_rising = '1') then -- [JTAG-SYNC] evaluate TDI on rising edge of TCK
-          if (tap_reg.ireg = adr_dtmcs_c) then
-            tap_reg.dtmcs <= tap_sync.tdi & tap_reg.dtmcs(tap_reg.dtmcs'left downto 1);
-          elsif (tap_reg.ireg = adr_dmi_c) then
-            tap_reg.dmi   <= tap_sync.tdi & tap_reg.dmi(tap_reg.dmi'left downto 1);
-          end if;
+          case tap_reg.ireg is
+            when addr_idcode_c => tap_reg.idcode <= tap_sync.tdi & tap_reg.idcode(tap_reg.idcode'left downto 1);
+            when addr_dtmcs_c  => tap_reg.dtmcs  <= tap_sync.tdi & tap_reg.dtmcs(tap_reg.dtmcs'left downto 1);
+            when addr_dmi_c    => tap_reg.dmi    <= tap_sync.tdi & tap_reg.dmi(tap_reg.dmi'left downto 1);
+            when others        => null;
+          end case;
         end if;
       end if;
 
@@ -243,24 +264,25 @@ begin
   end process reg_access;
 
   -- serial data output --
-  jtag_tdo_o <= tap_reg.dtmcs(0) when (tap_reg.ireg = adr_dtmcs_c) else
-                tap_reg.dmi(0)   when (tap_reg.ireg = adr_dmi_c) else
+  jtag_tdo_o <= tap_reg.idcode(0) when (tap_reg.ireg = addr_idcode_c) else
+                tap_reg.dtmcs(0)  when (tap_reg.ireg = addr_dtmcs_c)  else
+                tap_reg.dmi(0)    when (tap_reg.ireg = addr_dmi_c)    else
                 '0';
 
   -- DTM Control and Status Register (dtmcs) --
-  tap_reg.dtmcs_nxt(31 downto 18) <= (others => '0'); -- unused
-  tap_reg.dtmcs_nxt(17)           <= '0'; -- dmihardreset, always reads as zero
-  tap_reg.dtmcs_nxt(16)           <= '0'; -- dmireset, always reads as zero
-  tap_reg.dtmcs_nxt(15)           <= '0'; -- unused
+  tap_reg.dtmcs_nxt(31 downto 18) <= (others => '0'); -- reserved
+  tap_reg.dtmcs_nxt(17)           <= dmi_ctrl.dmihardreset; -- dmihardreset
+  tap_reg.dtmcs_nxt(16)           <= dmi_ctrl.dmireset; -- dmireset
+  tap_reg.dtmcs_nxt(15)           <= '0'; -- reserved
   tap_reg.dtmcs_nxt(14 downto 12) <= dmi_idle_c; -- minimum number of idle cycles
   tap_reg.dtmcs_nxt(11 downto 10) <= tap_reg.dmi_nxt(1 downto 0); -- dmistat
   tap_reg.dtmcs_nxt(09 downto 04) <= dmi_abits_c; -- number of DMI address bits
   tap_reg.dtmcs_nxt(03 downto 00) <= dmi_version_c; -- version
 
   -- DMI register read access --
-  tap_reg.dmi_nxt(39 downto 34) <= dmi_ctrl.addr; -- address
+  tap_reg.dmi_nxt(40 downto 34) <= dmi_ctrl.addr; -- address
   tap_reg.dmi_nxt(33 downto 02) <= dmi_ctrl.rdata; -- read data
-  tap_reg.dmi_nxt(01 downto 00) <= "11" when (dmi_ctrl.state /= DMI_IDLE) else (dmi_ctrl.rsp); -- status
+  tap_reg.dmi_nxt(01 downto 00) <= (others => dmi_ctrl.err); -- status
 
 
   -- Debug Module Interface -----------------------------------------------------------------
@@ -268,106 +290,62 @@ begin
   dmi_controller: process(rstn_i, clk_i)
   begin
     if (rstn_i = '0') then
-      dmi_ctrl.state        <= DMI_IDLE;
+      dmi_ctrl.busy         <= '0';
+      dmi_ctrl.op           <= "00";
       dmi_ctrl.dmihardreset <= '1';
-      dmi_ctrl.dmireset     <= '1';
-      dmi_ctrl.rsp          <= "00";
+      dmi_ctrl.dmireset     <= '0';
+      dmi_ctrl.err          <= '0';
       dmi_ctrl.rdata        <= (others => '0');
       dmi_ctrl.wdata        <= (others => '0');
       dmi_ctrl.addr         <= (others => '0');
     elsif rising_edge(clk_i) then
 
-      -- DMI status and control --
-      dmi_ctrl.dmihardreset <= '0'; -- default
-      dmi_ctrl.dmireset     <= '0'; -- default
-      if (dr_update_trig.valid = '1') and (tap_reg.ireg = adr_dtmcs_c) then
+      -- DMI reset control --
+      if (dr_trigger.valid = '1') and (tap_reg.ireg = addr_dtmcs_c) then
         dmi_ctrl.dmireset     <= tap_reg.dtmcs(16);
         dmi_ctrl.dmihardreset <= tap_reg.dtmcs(17);
+      elsif (dmi_ctrl.busy = '0') then
+        dmi_ctrl.dmihardreset <= '0';
+        dmi_ctrl.dmireset     <= '0';
+      end if;
+
+      -- sticky error --
+      if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
+        dmi_ctrl.err <= '0';
+      elsif (dmi_ctrl.busy = '1') and (dr_trigger.valid = '1') and (tap_reg.ireg = addr_dmi_c) then -- access attempt while DMI is busy
+        dmi_ctrl.err <= '1';
       end if;
 
       -- DMI interface arbiter --
-      if (dmi_ctrl.dmihardreset = '1') then -- DMI hard reset
-        dmi_ctrl.state <= DMI_IDLE;
-      else
-        case dmi_ctrl.state is
+      dmi_ctrl.op <= dmi_req_nop_c; -- default
+      if (dmi_ctrl.busy = '0') then -- idle: waiting for new request
 
-          when DMI_IDLE => -- waiting for new request
-            if (dr_update_trig.valid = '1') and (tap_reg.ireg = adr_dmi_c) then
-              dmi_ctrl.addr  <= tap_reg.dmi(39 downto 34);
-              dmi_ctrl.wdata <= tap_reg.dmi(33 downto 02);
-              if (tap_reg.dmi(1 downto 0) = "01") then -- read
-                dmi_ctrl.state <= DMI_READ_WAIT;
-              elsif (tap_reg.dmi(1 downto 0) = "10") then -- write
-                dmi_ctrl.state <= DMI_WRITE_WAIT;
-              end if;
+        if (dmi_ctrl.dmihardreset = '0') then -- no DMI hard reset
+          if (dr_trigger.valid = '1') and (tap_reg.ireg = addr_dmi_c) then
+            dmi_ctrl.addr  <= tap_reg.dmi(40 downto 34);
+            dmi_ctrl.wdata <= tap_reg.dmi(33 downto 02);
+            if (tap_reg.dmi(1 downto 0) = dmi_req_rd_c) or (tap_reg.dmi(1 downto 0) = dmi_req_wr_c) then
+              dmi_ctrl.op   <= tap_reg.dmi(1 downto 0);
+              dmi_ctrl.busy <= '1';
             end if;
-
-          when DMI_READ_WAIT => -- wait for DMI to become ready
-            if (dmi_req_ready_i = '1') then
-              dmi_ctrl.state <= DMI_READ;
-            end if;
-
-          when DMI_READ => -- trigger/start read access
-            dmi_ctrl.state <= DMI_READ_BUSY;
-
-          when DMI_READ_BUSY => -- pending read access
-            if (dmi_rsp_valid_i = '1') then
-              dmi_ctrl.rdata <= dmi_rsp_data_i;
-              dmi_ctrl.state <= DMI_IDLE;
-            end if;
-
-          when DMI_WRITE_WAIT => -- wait for DMI to become ready
-            if (dmi_req_ready_i = '1') then
-              dmi_ctrl.state <= DMI_WRITE;
-            end if;
-
-          when DMI_WRITE => -- trigger/start write access
-            dmi_ctrl.state <= DMI_WRITE_BUSY;
-
-          when DMI_WRITE_BUSY => -- pending write access
-            if (dmi_rsp_valid_i = '1') then
-              dmi_ctrl.state <= DMI_IDLE;
-            end if;
-
-          when others => -- undefined
-            dmi_ctrl.state <= DMI_IDLE;
-
-        end case;
-      end if;
-
-      -- sticky response flags --
-      if (dmi_ctrl.dmireset = '1') or (dmi_ctrl.dmihardreset = '1') then
-        dmi_ctrl.rsp <= "00";
-      else
-        if (dmi_ctrl.state /= DMI_IDLE) and (dr_update_trig.valid = '1') and (tap_reg.ireg = adr_dmi_c) then -- access attempt while DMI is busy
-          dmi_ctrl.rsp <= "11";
-        elsif (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) then -- accumulate DMI response
-          dmi_ctrl.rsp <= dmi_ctrl.rsp or dmi_rsp_op_i;
+          end if;
         end if;
-      end if;
 
+        else -- busy: read/write access in progress
+
+          dmi_ctrl.rdata <= dmi_rsp_i.data;
+          if (dmi_rsp_i.ack = '1') then
+            dmi_ctrl.busy <= '0';
+          end if;
+
+      end if;
     end if;
   end process dmi_controller;
 
-  -- trigger for UPDATE state --
-  tap_update_trigger: process(rstn_i, clk_i)
-  begin
-    if (rstn_i = '0') then
-      dr_update_trig.is_update_ff <= '0';
-    elsif rising_edge(clk_i) then
-      dr_update_trig.is_update_ff <= dr_update_trig.is_update;
-    end if;
-  end process tap_update_trigger;
-
-  dr_update_trig.is_update <= '1' when (tap_ctrl_state = DR_UPDATE) else '0';
-  dr_update_trig.valid     <= '1' when (dr_update_trig.is_update = '1') and (dr_update_trig.is_update_ff = '0') else '0';
-
   -- direct DMI output --
-  dmi_req_valid_o   <= '1' when (dmi_ctrl.state = DMI_READ) or (dmi_ctrl.state = DMI_WRITE) else '0';
-  dmi_req_op_o      <= tap_reg.dmi(1 downto 0);
-  dmi_rsp_ready_o   <= '1' when (dmi_ctrl.state = DMI_READ_BUSY) or (dmi_ctrl.state = DMI_WRITE_BUSY) else '0';
-  dmi_req_address_o <= dmi_ctrl.addr;
-  dmi_req_data_o    <= dmi_ctrl.wdata;
+  dmi_req_o.op   <= dmi_ctrl.op;
+  dmi_req_o.data <= dmi_ctrl.wdata;
+  dmi_req_o.addr <= dmi_ctrl.addr;
 
 
 end neorv32_debug_dtm_intel_rtl;

--- a/quartus/on-chip-debugger-intel/neorv32_on_chip_debugger_intel_top.vhd
+++ b/quartus/on-chip-debugger-intel/neorv32_on_chip_debugger_intel_top.vhd
@@ -109,7 +109,7 @@ begin
     -- RISC-V CPU Extensions --
     CPU_EXTENSION_RISCV_C        => true,              -- implement compressed extension?
     CPU_EXTENSION_RISCV_M        => true,              -- implement mul/div extension?
-    CPU_EXTENSION_RISCV_Zicsr    => true,              -- implement CSR system?
+    CPU_EXTENSION_RISCV_U        => true,              -- implement user mode extension?
     CPU_EXTENSION_RISCV_Zicntr   => true,              -- implement base counters?
     CPU_EXTENSION_RISCV_Zifencei => true,              -- implement instruction stream sync.? (required for the on-chip debugger)
     -- Internal Instruction memory --
@@ -119,7 +119,7 @@ begin
     MEM_INT_DMEM_EN              => true,              -- implement processor-internal data memory
     MEM_INT_DMEM_SIZE            => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
-    IO_GPIO_EN                   => true,              -- implement general purpose input/output port unit (GPIO)?
+    IO_GPIO_NUM                  => 8,                 -- number of GPIO input/output pairs (0..64)
     IO_MTIME_EN                  => true               -- implement machine system timer (MTIME)?
   )
   port map (
@@ -132,7 +132,7 @@ begin
     jtag_tdi_i  => con_jtag_tdi, -- serial data input
     jtag_tdo_o  => con_jtag_tdo, -- serial data output
     jtag_tms_i  => con_jtag_tms, -- mode select
-    -- GPIO (available if IO_GPIO_EN = true) --
+    -- GPIO (available if IO_GPIO_NUM > 0) --
     gpio_o      => con_gpio_o    -- parallel output
   );
 


### PR DESCRIPTION
Hi there @stnolting

As [discussed](https://github.com/stnolting/neorv32/pull/677) this updates the custom Intel FPGA specific DTM to have the identical entity ports as in the new default DTM. 🚂

I modified the file header a bit (copyright), let me know if I shall change it back or change anything else. 😊

Open tasks:
 - [x] wait on dependabot pr with submodule update
 - [x] check if setup is synthesizing
 - [x] check setup on real hardware