### PR TITLE
Fix minor issues preventing Linux compatibility and update path in README

### DIFF
--- a/quartus/de0-nano-test-setup/README.md
+++ b/quartus/de0-nano-test-setup/README.md
@@ -51,7 +51,7 @@ If not already available, this script will create a `work` folder in this direct
 
 1. start Quartus (in GUI mode)
 2. in the menu line click "View/Utility Windows/Tcl console" to open the Tcl console
-3. use the console to naviagte to **this** folder: `cd .../neorv32/boards/de0-nano-test-setup`
+3. use the console to naviagte to **this** folder: `cd .../neorv32-setups/quartus/de0-nano-test-setup`
 4. execute `source create_project.tcl` - this will create and open the actual Quartus project in this folder
 5. if a "select family" prompt appears select the "Cyclone IV E" family and click OK
 6. double click on "Compile Design" in the "Tasks" window. This will synthesize, map and place & route your design and will also generate the actual FPGA bitstream

--- a/quartus/de0-nano-test-setup/create_project.tcl
+++ b/quartus/de0-nano-test-setup/create_project.tcl
@@ -1,6 +1,6 @@
 # make a local copy of original "./../../rtl/test_setups/neorv32_test_setup_bootloader.vhd " file
 # and modify the default clock frequency: set to 50MHz
-set shell_script "cp -f ./../../NEORV32/rtl/test_setups/neorv32_test_setup_bootloader.vhd  . && sed -i 's/100000000/50000000/g' neorv32_test_setup_bootloader.vhd "
+set shell_script "cp -f ./../../neorv32/rtl/test_setups/neorv32_test_setup_bootloader.vhd  . && sed -i 's/100000000/50000000/g' neorv32_test_setup_bootloader.vhd "
 exec sh -c $shell_script
 
 # Copyright (C) 2020  Intel Corporation. All rights reserved.
@@ -58,7 +58,7 @@ if {$make_assignments} {
   set_global_assignment -name ERROR_CHECK_FREQUENCY_DIVISOR 1
 
   # core VHDL files
-  set core_src_dir [glob ./../../NEORV32/rtl/core/*.vhd]
+  set core_src_dir [glob ./../../neorv32/rtl/core/*.vhd]
   foreach core_src_file $core_src_dir {
     set_global_assignment -name VHDL_FILE $core_src_file -library neorv32
   }


### PR DESCRIPTION
The paths in the create_project.tcl file were in uppercase, which causes it to fail on Linux due to the case-sensitive filesystem. I have changed these to lowercase, which fixes it, and should have no effect on Windows as far as I know.

I have also updated the path given for the create_project.tcl file in the README file, to reflect its actual location. As they are both minor changes I have included them in the same PR.