### PR TITLE
Update the osvb/impl container hosts because they were deleted from google cloud

### DIFF
--- a/.github/impl.dockerfile
+++ b/.github/impl.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/hdl-containers/debian/bullseye/impl
+FROM ghcr.io/hdl/debian/bullseye/impl
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \

--- a/.github/sim.dockerfile
+++ b/.github/sim.dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/hdl-containers/debian/bullseye/sim/osvb
+FROM ghcr.io/hdl/debian/bullseye/sim/osvb
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \


### PR DESCRIPTION
Hi Stephan!

This PR updates the osvb/impl container hosts because they were deleted from google cloud.

Updated from:

`gcr.io/hdl-containers/...`

To:

`ghcr.io/hdl/...`

The CI was breaking down, as shown in the following image:

![PR_containers](https://github.com/user-attachments/assets/f4fc1c69-7fd3-4949-9920-1ab20e1b96b3)

Cheers! :smile: 

---

/cc @umarcor