### PR TITLE
Fix Vivado TCL

### DIFF
--- a/vivado/arty-a7-test-setup/create_project.tcl
+++ b/vivado/arty-a7-test-setup/create_project.tcl
@@ -38,7 +38,7 @@ set fileset_design ./../../neorv32/rtl/test_setups/neorv32_test_setup_bootloader
 set fileset_constraints [glob ./*.xdc]
 
 ## Simulation-only sources
-set fileset_sim [list ./../../neorv32/sim/simple/neorv32_tb.simple.vhd ./../../neorv32/sim/simple/uart_rx.simple.vhd]
+set fileset_sim [list ./../../neorv32/sim/neorv32_tb.vhd ./../../neorv32/sim/sim_uart_rx.vhd]
 
 # Add source files
 

--- a/vivado/nexys-a7-test-setup/create_project.tcl
+++ b/vivado/nexys-a7-test-setup/create_project.tcl
@@ -34,7 +34,7 @@ set_property library neorv32 [get_files [glob ./../../neorv32/rtl/core/*.vhd]]
 add_files [glob ./../../neorv32/rtl/test_setups/neorv32_test_setup_bootloader.vhd]
 
 # add source files: simulation-only
-add_files -fileset sim_1 [list ./../../neorv32/sim/simple/neorv32_tb.simple.vhd ./../../neorv32/sim/simple/uart_rx.simple.vhd]
+add_files -fileset sim_1 [list ./../../neorv32/sim/neorv32_tb.vhd ./../../neorv32/sim/sim_uart_rx.vhd]
 
 # add source files: constraints
 add_files -fileset constrs_1 [glob ./*.xdc]


### PR DESCRIPTION
Hi Stephan!

This PR updates the testbench paths in the Vivado TCL scripts.

Due to recent changes, the execution of the `create_project.tcl` script was failing because the testbench paths were updated. I’ve corrected the TCL files to reflect these changes.

Current error during `create_project.tcl` execution:

![Error_vivado_tcl](https://github.com/user-attachments/assets/aa43ad61-ca4e-4ff5-bc45-307fd5d1bd73)

Cheers and Happy New Year!!!! :heart: 