### PR TITLE
Update IMEM/DMEM configuration generics

### DIFF
--- a/cologne_chip/GateMateA1-EVB/neorv32_gatemate.vhd
+++ b/cologne_chip/GateMateA1-EVB/neorv32_gatemate.vhd
@@ -106,11 +106,11 @@ begin
     RISCV_ISA_M       => true,
     RISCV_ISA_Zicntr  => true,
     -- Internal instruction memory --
-    MEM_INT_IMEM_EN   => true,
-    MEM_INT_IMEM_SIZE => 16*1024,
+    IMEM_EN   => true,
+    IMEM_SIZE => 16*1024,
     -- Internal data memory --
-    MEM_INT_DMEM_EN   => true,
-    MEM_INT_DMEM_SIZE => 8*1024,
+    DMEM_EN   => true,
+    DMEM_SIZE => 8*1024,
     -- Processor peripherals --
     IO_GPIO_NUM       => 1,
     IO_CLINT_EN       => true,

--- a/gowineda/tang-nano-20k/test_setups/neorv32_test_setup_bootloader.vhd
+++ b/gowineda/tang-nano-20k/test_setups/neorv32_test_setup_bootloader.vhd
@@ -19,8 +19,8 @@ entity neorv32_test_setup_bootloader is
   generic (
     -- adapt these for your setup --
     CLOCK_FREQUENCY   : natural := 100000000; -- clock frequency of clk_i in Hz
-    MEM_INT_IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
-    MEM_INT_DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
+    IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
+    DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
   );
   port (
     -- Global control --
@@ -57,11 +57,11 @@ begin
     RISCV_ISA_M       => true,              -- implement mul/div extension?
     RISCV_ISA_Zicntr  => true,              -- implement base counters?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN   => true,              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    IMEM_EN   => true,              -- implement processor-internal instruction memory
+    IMEM_SIZE => IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN   => true,              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    DMEM_EN   => true,              -- implement processor-internal data memory
+    DMEM_SIZE => DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
     IO_GPIO_NUM       => 8,                 -- number of GPIO input/output pairs (0..32)
     IO_CLINT_EN       => true,              -- implement core local interruptor (CLINT)?

--- a/quartus/de0-nano-test-setup-avalonmm-wrapper/neorv32_test_setup_avalonmm.vhd
+++ b/quartus/de0-nano-test-setup-avalonmm-wrapper/neorv32_test_setup_avalonmm.vhd
@@ -47,8 +47,8 @@ entity neorv32_test_setup_avalonmm is
   generic (
     -- adapt these for your setup --
     CLOCK_FREQUENCY   : natural := 50000000; -- clock frequency of clk_i in Hz
-    MEM_INT_IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
-    MEM_INT_DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
+    IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
+    DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
   );
   port (
     -- Global control --
@@ -96,12 +96,12 @@ architecture neorv32_test_setup_avalonmm_rtl of neorv32_test_setup_avalonmm is
       HPM_CNT_WIDTH                : natural := 40;     -- total size of HPM counters (0..64)
   
       -- Internal Instruction memory (IMEM) --
-      MEM_INT_IMEM_EN              : boolean := false;  -- implement processor-internal instruction memory
-      MEM_INT_IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes
+      IMEM_EN              : boolean := false;  -- implement processor-internal instruction memory
+      IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes
   
       -- Internal Data memory (DMEM) --
-      MEM_INT_DMEM_EN              : boolean := false;  -- implement processor-internal data memory
-      MEM_INT_DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes
+      DMEM_EN              : boolean := false;  -- implement processor-internal data memory
+      DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes
   
       -- Internal Cache memory (iCACHE) --
       ICACHE_EN                    : boolean := false;  -- implement instruction cache
@@ -262,11 +262,11 @@ begin
     RISCV_ISA_M        => true,              -- implement mul/div extension?
     RISCV_ISA_Zicsr    => true,              -- implement CSR system?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => true,              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    IMEM_EN              => true,              -- implement processor-internal instruction memory
+    IMEM_SIZE            => IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              => false,              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => 0,                  -- size of processor-internal data memory in bytes
+    DMEM_EN              => false,              -- implement processor-internal data memory
+    DMEM_SIZE            => 0,                  -- size of processor-internal data memory in bytes
     -- Processor peripherals --
     IO_GPIO_EN                   => true,              -- implement general purpose input/output port unit (GPIO)?
     IO_MTIME_EN                  => true,              -- implement machine system timer (MTIME)?

--- a/quartus/de10-nano-test-setup/neorv32_test_setup_bootloader.vhd
+++ b/quartus/de10-nano-test-setup/neorv32_test_setup_bootloader.vhd
@@ -19,8 +19,8 @@ entity neorv32_test_setup_bootloader is
   generic (
     -- adapt these for your setup --
     CLOCK_FREQUENCY   : natural := 50_000_000; -- clock frequency of clk_i in Hz
-    MEM_INT_IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
-    MEM_INT_DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
+    IMEM_SIZE : natural := 16*1024;   -- size of processor-internal instruction memory in bytes
+    DMEM_SIZE : natural := 8*1024     -- size of processor-internal data memory in bytes
   );
   port (
     -- Global control --
@@ -53,11 +53,11 @@ begin
     RISCV_ISA_M       => true,              -- implement mul/div extension?
     RISCV_ISA_Zicntr  => true,              -- implement base counters?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN   => true,              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    IMEM_EN   => true,              -- implement processor-internal instruction memory
+    IMEM_SIZE => IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN   => true,              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    DMEM_EN   => true,              -- implement processor-internal data memory
+    DMEM_SIZE => DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
     IO_GPIO_NUM       => 8,                 -- number of GPIO input/output pairs (0..64)
     IO_CLINT_EN       => true,              -- implement core local interruptor (CLINT)?

--- a/quartus/neorv32_SystemTop_AvalonMM.vhd
+++ b/quartus/neorv32_SystemTop_AvalonMM.vhd
@@ -51,12 +51,12 @@ entity neorv32_top_avalonmm is
     HPM_CNT_WIDTH                : natural := 40;     -- total size of HPM counters (0..64)
 
     -- Internal Instruction memory (IMEM) --
-    MEM_INT_IMEM_EN              : boolean := false;  -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes
+    IMEM_EN              : boolean := false;  -- implement processor-internal instruction memory
+    IMEM_SIZE            : natural := 16*1024; -- size of processor-internal instruction memory in bytes
 
     -- Internal Data memory (DMEM) --
-    MEM_INT_DMEM_EN              : boolean := false;  -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes
+    DMEM_EN              : boolean := false;  -- implement processor-internal data memory
+    DMEM_SIZE            : natural := 8*1024; -- size of processor-internal data memory in bytes
 
     -- Internal Cache memory (iCACHE) --
     ICACHE_EN                    : boolean := false;  -- implement instruction cache
@@ -233,12 +233,12 @@ begin
     HPM_CNT_WIDTH => HPM_CNT_WIDTH,
 
     -- Internal Instruction memory (IMEM) --
-    MEM_INT_IMEM_EN => MEM_INT_IMEM_EN,
-    MEM_INT_IMEM_SIZE => MEM_INT_IMEM_SIZE,
+    IMEM_EN => IMEM_EN,
+    IMEM_SIZE => IMEM_SIZE,
 
     -- Internal Data memory (DMEM) --
-    MEM_INT_DMEM_EN => MEM_INT_IMEM_EN,
-    MEM_INT_DMEM_SIZE => MEM_INT_DMEM_SIZE,
+    DMEM_EN => IMEM_EN,
+    DMEM_SIZE => DMEM_SIZE,
 
     -- Internal Cache memory (iCACHE) --
     ICACHE_EN => ICACHE_EN,

--- a/quartus/neorv32_qsys_component/neorv32_qsys.vhd
+++ b/quartus/neorv32_qsys_component/neorv32_qsys.vhd
@@ -138,11 +138,11 @@ begin
     HPM_NUM_CNTS                 => 4,           -- number of implemented HPM counters (0..29)
     HPM_CNT_WIDTH                => 40,          -- total size of HPM counters (0..64)
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN              => integer2bool(GUI_EMABLE_INTERNAL_IMEM),        -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE            => GUI_IMEM_SIZE*1024,     -- size of processor-internal instruction memory in bytes
+    IMEM_EN              => integer2bool(GUI_EMABLE_INTERNAL_IMEM),        -- implement processor-internal instruction memory
+    IMEM_SIZE            => GUI_IMEM_SIZE*1024,     -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN              => integer2bool(GUI_EMABLE_INTERNAL_DMEM),        -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE            => GUI_DMEM_SIZE*1024,      -- size of processor-internal data memory in bytes
+    DMEM_EN              => integer2bool(GUI_EMABLE_INTERNAL_DMEM),        -- implement processor-internal data memory
+    DMEM_SIZE            => GUI_DMEM_SIZE*1024,      -- size of processor-internal data memory in bytes
     -- Internal Cache memory --
     ICACHE_EN                    => false,       -- implement instruction cache
     ICACHE_NUM_BLOCKS            => 4,           -- i-cache: number of blocks (min 1), has to be a power of 2

--- a/quartus/on-chip-debugger-intel/neorv32_on_chip_debugger_intel_top.vhd
+++ b/quartus/on-chip-debugger-intel/neorv32_on_chip_debugger_intel_top.vhd
@@ -43,8 +43,8 @@ entity neorv32_on_chip_debugger_intel is
   generic (
     -- adapt these for your setup --
     CLOCK_FREQUENCY   : natural := 50000000; -- clock frequency of clk_i in Hz
-    MEM_INT_IMEM_SIZE : natural := 16*1024;  -- size of processor-internal instruction memory in bytes
-    MEM_INT_DMEM_SIZE : natural := 8*1024    -- size of processor-internal data memory in bytes
+    IMEM_SIZE : natural := 16*1024;  -- size of processor-internal instruction memory in bytes
+    DMEM_SIZE : natural := 8*1024    -- size of processor-internal data memory in bytes
   );
   port (
     -- Global control --
@@ -112,11 +112,11 @@ begin
     RISCV_ISA_U         => true,              -- implement user mode extension?
     RISCV_ISA_Zicntr    => true,              -- implement base counters?
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN     => true,              -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE   => MEM_INT_IMEM_SIZE, -- size of processor-internal instruction memory in bytes
+    IMEM_EN     => true,              -- implement processor-internal instruction memory
+    IMEM_SIZE   => IMEM_SIZE, -- size of processor-internal instruction memory in bytes
     -- Internal Data memory --
-    MEM_INT_DMEM_EN     => true,              -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE   => MEM_INT_DMEM_SIZE, -- size of processor-internal data memory in bytes
+    DMEM_EN     => true,              -- implement processor-internal data memory
+    DMEM_SIZE   => DMEM_SIZE, -- size of processor-internal data memory in bytes
     -- Processor peripherals --
     IO_GPIO_NUM         => 8,                 -- number of GPIO input/output pairs (0..64)
     IO_MTIME_EN         => true               -- implement machine system timer (MTIME)?

--- a/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
+++ b/radiant/UPduino_v3/neorv32_upduino_v3_top.vhd
@@ -148,12 +148,12 @@ begin
     RISCV_ISA_Zicntr   => true,        -- implement base counters?
 
     -- Internal Instruction memory --
-    MEM_INT_IMEM_EN    => true,        -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE  => 64*1024,     -- size of processor-internal instruction memory in bytes
+    IMEM_EN    => true,        -- implement processor-internal instruction memory
+    IMEM_SIZE  => 64*1024,     -- size of processor-internal instruction memory in bytes
 
     -- Internal Data memory --
-    MEM_INT_DMEM_EN    => true,        -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE  => 64*1024,     -- size of processor-internal data memory in bytes
+    DMEM_EN    => true,        -- implement processor-internal data memory
+    DMEM_SIZE  => 64*1024,     -- size of processor-internal data memory in bytes
 
     -- Processor peripherals --
     IO_GPIO_NUM        => 4,           -- implement general purpose input/output port unit (GPIO)?

--- a/radiant/iCEBreaker/icebreaker_top.vhd
+++ b/radiant/iCEBreaker/icebreaker_top.vhd
@@ -146,12 +146,12 @@ begin
     RISCV_ISA_Zicond  => true,      -- implement integer conditional operations?
 
     -- Internal Instruction memory (IMEM) --
-    MEM_INT_IMEM_EN   => true,      -- implement processor-internal instruction memory
-    MEM_INT_IMEM_SIZE => 64*1024,   -- size of processor-internal instruction memory in bytes
+    IMEM_EN   => true,      -- implement processor-internal instruction memory
+    IMEM_SIZE => 64*1024,   -- size of processor-internal instruction memory in bytes
 
     -- Internal Data memory (DMEM) --
-    MEM_INT_DMEM_EN   => true,      -- implement processor-internal data memory
-    MEM_INT_DMEM_SIZE => 64*1024,   -- size of processor-internal data memory in bytes
+    DMEM_EN   => true,      -- implement processor-internal data memory
+    DMEM_SIZE => 64*1024,   -- size of processor-internal data memory in bytes
 
     -- Processor peripherals --
     IO_GPIO_NUM       => 32,        -- number of GPIO input/output pairs (0..64)


### PR DESCRIPTION
Hi Stephan!

In order to adapt to https://github.com/stnolting/neorv32/pull/1280

> [!NOTE]
>  To perform the operation the following commands are applied:
> `grep -nRl 'MEM_INT_DMEM_SIZE' . | xargs sed -i 's|MEM_INT_DMEM_SIZE|DMEM_SIZE|g' `
> `grep -nRl 'MEM_INT_DMEM_EN' . | xargs sed -i 's|MEM_INT_DMEM_EN|DMEM_EN|g'`
> `grep -nRl 'MEM_INT_IMEM_SIZE' . | xargs sed -i 's|MEM_INT_IMEM_SIZE|IMEM_SIZE|g'`
> `grep -nRl 'MEM_INT_IMEM_EN' . | xargs sed -i 's|MEM_INT_IMEM_EN|IMEM_EN|g'` 

Cheers!