### PR TITLE
Delete XBUS_TIMEOUT generic in quartus top file

### DIFF
--- a/quartus/neorv32_SystemTop_AvalonMM.vhd
+++ b/quartus/neorv32_SystemTop_AvalonMM.vhd
@@ -252,7 +252,6 @@ begin
 
     -- External bus interface (XBUS) --
     XBUS_EN => true,
-    XBUS_TIMEOUT => 0,
     XBUS_REGSTAGE_EN => true,
 
     -- Execute in-place module (XIP) --


### PR DESCRIPTION
Hi Stephan!

In order to adapt to https://github.com/stnolting/neorv32/pull/1339, the deprecated generic `XBUS_TIMEOUT` must be removed from the quartus top file.

Cheers!